### PR TITLE
Catch StopIteration in AbstractTable._enumerate_items

### DIFF
--- a/prettytoml/elements/abstracttable.py
+++ b/prettytoml/elements/abstracttable.py
@@ -19,7 +19,10 @@ class AbstractTable(ContainerElement, traversal.TraversalMixin):
         """
         non_metadata = self._enumerate_non_metadata_sub_elements()
         while True:
-            yield next(non_metadata), next(non_metadata)
+            try:
+                yield next(non_metadata), next(non_metadata)
+            except StopIteration:
+                return
 
     def items(self):
         for (key_i, key), (value_i, value) in self._enumerate_items():


### PR DESCRIPTION
This was, PEP 479 enabled Pythons (such as 3.7) work again.

Otherwise you get:

    RuntimeError: generator raised StopIteration

Fixes https://github.com/pypa/pipenv/issues/2426